### PR TITLE
Move "members" key to end of "workspace" table

### DIFF
--- a/src/formatting/cargo_toml.rs
+++ b/src/formatting/cargo_toml.rs
@@ -151,6 +151,22 @@ impl VisitMut for SortKey {
                     (_, "description") => Ordering::Less,
                     _ => k1.cmp(k2),
                 })
+            } else if key == "workspace" {
+                let table = match section.as_table_mut() {
+                    Some(table) => table,
+                    None => {
+                        // workspace should be a table
+                        self.error = Some(ErrorKind::ParseError);
+                        return;
+                    }
+                };
+                // "members" is last
+                // everything else is sorted alphabetically
+                table.sort_values_by(|k1, _, k2, _| match (k1.get(), k2.get()) {
+                    ("members", _) => Ordering::Greater,
+                    (_, "members") => Ordering::Less,
+                    _ => k1.cmp(k2),
+                })
             } else {
                 self.visit_item_mut(section)
             }

--- a/src/formatting/cargo_toml.rs
+++ b/src/formatting/cargo_toml.rs
@@ -258,8 +258,12 @@ impl VisitMut for KeyValue {
             // will remove decors and set the key to the bare key
             key.fmt();
         } else {
-            // add a space after the key
-            key.decor_mut().set_suffix(" ");
+            if value.is_value() {
+                // add a space after the key
+                key.decor_mut().set_suffix(" ");
+            } else {
+                key.decor_mut().set_suffix("");
+            }
         }
         // start all key names at the start of a line, but preserve comments
         key.decor_mut()


### PR DESCRIPTION
While not specified in the [style guide](https://github.com/rust-lang/rust/blob/master/src/doc/style-guide/src/cargo.md), it feels clear enough that the "members" key should be placed at the end of the "workspace" table. The "members" list can be long, so the end of its section feels like the only natural place for it.